### PR TITLE
[FEAT] Add training augmentation via MixUp, Audio Preprocessing Polishes, LLM2Vec PCA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ Thumbs.db
 data/raw/
 data/processed/
 data/external/
+data/.tmp.driveupload/
 *.csv
 *.tsv
 *.xlsx

--- a/config/data_config.yml
+++ b/config/data_config.yml
@@ -5,3 +5,4 @@ paths:
   dataset_csv: "data/external/songs_dataset.csv"
   raw_dir: "data/raw"
   processed_dir: "data/processed"
+  pca_path: "data/processed/pca_model.pkl"

--- a/config/model_config.yml
+++ b/config/model_config.yml
@@ -8,3 +8,4 @@ mlp:
 
   weight_decay: 0.1 # L2 regularization
   gradient_clipping: 0.5 # Prevent exploding gradients
+  mixup_alpha: 0.2   # For data augmentation during trainign, 0 disables MixUp

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -1,0 +1,92 @@
+# Preprocessing Documentation
+This document will serve as a general guide towards method implementations of preprocessing for our thesis!
+
+## Preprocessing Methods
+For our preprocessing, we have two main classes that we can use:
+- `AudioPreprocessor`
+- `LyricsPreprocessor`
+
+Both classes needs to be instantiated before usage. Methods for accessing and instantiating said classes can be accessed via `preprocessor.py`
+
+---
+### `preprocessor.py`
+Located at *src/preprocessing/preprocessor.py*, this file has several methods that can be accessed for preprocessing:
+
+`dataset_read(batch_size = 20)`
+- Reads the main `.csv` file, and returns the batches of data.
+- **Parameters:** 
+	- `batch_size` → `int`. Determines the number of splits.
+- **Returns:** 
+	-  `data_splits`, a list of `pd.DataFrame` from the split and.
+	- `label`, a list of `boolean` values representing real or fake.
+
+
+`single_preprocessing(audio, lyric: str)`
+- Preprocess a single record of audio and lyric data. The audio parameter provided can be a file and does not need to be saved in the disk.
+- **Parameters:**
+	- `file` → `[str/audio_object]`. 
+		- It can take either a file name and load it from the disk or,
+		- Take in an audio object which is most likely coming from an API.
+	- `lyric` → `str`, a lyrical string.
+- **Returns:**
+	- `processed_song` → `tensor` of waveform, for feature extraction.
+	- `processed_lyric` → `str`, for feature extraction.
+
+
+`bulk_preprocessing(batch: pd.DataFrame, batch_count: int)`
+- Reads through the `DataFrame`, loads audio from disk and lyrics from `.csv`, applies preprocessing and returns preprocessed lists.
+- **Parameters:**
+	- `batch` → `pd.DataFrame`, containing sub-split of values.
+	- `batch_count` → `int`, used to display what batch is being processed.
+- **Returns:**
+	- `audio_list` → `list`, containing `tensors`.
+	- `lyric_list` → `list`, containing lyrics in `str` type.
+
+---
+### `AudioPreprocessor`
+This class located inside the preprocessing folder implements the basic audio preprocessing methods.
+
+**Instantiation**
+We can instantiate the class via: 
+`AudioPreprocessor(script="train", waveform_norm="std")`
+- `script` determines if the audio preprocessor will apply training methods (random cropping, gaussian noise) or not. Leave blank if using it for training, use `predict` if inferencing/predicting.
+- `waveform_norm` determines normalization that will be applied to the waveform. In default it uses `std`, which is also used by SpecTTTra.
+
+The only relevant script for training and production is the following:
+
+`__call__(file, skip_time=0, train=False)`
+- This method can be called by plainly using the instantiated class instance like `audio_preprocessor(file1, 2.3, True)`
+- **Parameters:**
+	- `file` → `[str/audio_object]`. 
+		- It can take either a file name and load it from the disk or,
+		- Take in an audio object which is most likely coming from an API.
+	- `skip_time` → `int`, determines the amount of seconds to skip through before the start of vocals.
+	- `train` → `str`, determines if the preprocessor class will use training methods or opt for prediction.
+- **Returns:**
+	- `waveform` → `tensor` version of the audio.
+
+---
+### `LyricsPreprocessor`
+This class located inside the preprocessing folder implements the basic lyric preprocessing methods.
+
+**Instantiation**
+We can instantiate the class via:
+`LyricsPreprocessor(keep_case=True, keep_punctuation=True)`
+- `keep_case`→`bool` determines whether or not the lyrics will be kept to its true form or `lower()` will be applied.
+- `keep_punctuation`→`bool` determines whether or not the punctuations will be kept within the lyrics or if they will be removed.
+
+There are two relevant scripts for this preprocessing class:
+
+`__call__(lyrics: str)`
+- This method can be called by plainly using the instantiated class instance like `lyrics_preprocessor(lyric1)`
+- **Parameters:**
+	- `lyrics` → `str`, takes up a raw string of lyrics for preprocessing
+- **Returns:**
+	- `lyrics_cleaned` → `str`, preprocessed string of lyrics.
+
+`musiclime_lyrics_extractor(lyrics: str)`
+- Preprocesses a lyrics and segments it into individual lines, stored in a list.
+- **Parameters:**
+	- `lyrics` → `str`, takes up a raw string of lyrics for preprocessing
+- **Returns:**
+	- `line_segmented_lyrics` → `list`, collection of lines from the lyrics.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -104,7 +104,7 @@ def train_pipeline():
         llm2vec_model = load_llm2vec_model()
 
         # Preallocate space for the whole concatenated sequence (50,000 samples)
-        X = np.zeros((len(Y), 4480), dtype=np.float32)
+        X = np.zeros((len(Y), 684), dtype=np.float32)
 
         start_idx = 0
         for batch in batches:

--- a/src/llm2vectrain/llm2vec_trainer.py
+++ b/src/llm2vectrain/llm2vec_trainer.py
@@ -1,12 +1,52 @@
 import torch
+import joblib
+from sklearn.decomposition import IncrementalPCA
 
-# For Single Input
-def l2vec_single_train(l2v, lyrics):
-    vectors = l2v.encode([lyrics])
-    return vectors
+# For Single Input (Inference)
+def l2vec_single_train(
+    l2v, lyrics,
+    pca_path="data/processed/pca_model.pkl" #Change directory
+):
+    # Encode single song
+    vectors = l2v.encode([lyrics])  # shape: (1, hidden_dim)
 
-# For Batch Processing
-def l2vec_train(l2v, lyrics_list):
-    with torch.no_grad():
-        vectors = l2v.encode(lyrics_list).detach().cpu().numpy()
-    return vectors
+    # Load trained IncrementalPCA
+    pca = joblib.load(pca_path)
+
+    # Apply transform (don't refit!)
+    reduced_vectors = pca.transform(vectors)  # shape: (1, n_components)
+    return reduced_vectors
+
+
+# For Batch Processing (Training)
+def l2vec_train(
+    l2v, lyrics_batches,
+    n_components=300,
+    batch_size=512,
+    save_pca=True,
+    pca_path="data/processed/pca_model.pkl"
+):
+    # Initialize IncrementalPCA
+    ipca = IncrementalPCA(n_components=n_components, batch_size=batch_size)
+
+    # First pass: fit PCA incrementally across all batches
+    for lyrics_list in lyrics_batches:
+        with torch.no_grad():
+            vectors = l2v.encode(lyrics_list).detach().cpu().numpy()
+        ipca.partial_fit(vectors)
+        print(f"Fitted batch of size {len(lyrics_list)}")
+
+    # Second pass: transform all batches consistently
+    reduced_all = []
+    for lyrics_list in lyrics_batches:
+        with torch.no_grad():
+            vectors = l2v.encode(lyrics_list).detach().cpu().numpy()
+        reduced_vectors = ipca.transform(vectors)
+        reduced_all.append(reduced_vectors)
+        print(f"Processed batch of size {len(lyrics_list)}")
+
+    # Save PCA object for later use in inference
+    if save_pca:
+        joblib.dump(ipca, pca_path)
+
+    return reduced_all

--- a/src/preprocessing/audio_preprocessor.py
+++ b/src/preprocessing/audio_preprocessor.py
@@ -15,33 +15,29 @@ CURRENT_PATH = Path().absolute()
 class AudioPreprocessor:
     """
     AudioPreprocessor is a utility class for loading, preprocessing, and converting
-    raw audio waveforms into normalized log-Mel spectrograms.
+    raw audio waveforms into normalized tensor waveforms.
 
     The preprocessing pipeline includes:
     - Loading audio from disk
     - Resampling to a target sampling rate (default: 16 kHz)
     - Trimming or padding to a fixed length (default: 120 seconds)
     - Waveform normalization (per-sample)
-    - Mel-spectrogram computation
-    - Log-scaling and spectrogram normalization
-    - Saving spectrograms as `.npy` files
+    - Returning or saving waveforms for testing.
+
 
     Parameters
     ----------
-    label : str
-        The label associated with the audio files ("real", "fake", etc.).
+    script : {"train"}, optional
+        Condition to apply certain training methods
+        
     waveform_norm : {"std", "minmax"}, optional
         Normalization method for waveforms:
         - "std": divide by standard deviation
         - "minmax": scale to [0, 1]
-    spec_norm : {"mean_std", "min_max", "simple"}, optional
-        Normalization method for spectrograms:
-        - "mean_std": standardize to zero mean, unit variance
-        - "min_max": scale to [0, 1]
-        - "simple": scale using (S - 40)/80 (used in some works)
+
     """
 
-    def __init__(self, script="train", waveform_norm="std", spec_norm="min_max"):
+    def __init__(self, script="train", waveform_norm="std"):
         self.SCRIPT = script
         self.INPUT_SAMPLING = 48000
         self.TARGET_SAMPLING = 16000
@@ -49,7 +45,6 @@ class AudioPreprocessor:
         self.INPUT_PATH = CURRENT_PATH / RAW_DIR
         self.OUTPUT_PATH = CURRENT_PATH / PROCESSED_DIR
         self.WAVEFORM_NORM = waveform_norm
-        self.SPEC_NORM = spec_norm
 
 
     def load_audio(self, audiofile):

--- a/src/preprocessing/audio_preprocessor.py
+++ b/src/preprocessing/audio_preprocessor.py
@@ -1,5 +1,7 @@
 import torchaudio
 import io
+import torch
+import random
 
 from pathlib import Path
 from torchaudio import functional as AF
@@ -110,32 +112,40 @@ class AudioPreprocessor:
         return waveform
         
 
-    def pad_trim(self, waveform):
+    def pad_trim(self, waveform, random_crop=False):
         """
         Pad or trim waveform to exactly `TARGET_NUM_SAMPLE`.
+        If `random_crop=True`, perform random cropping or random padding.
 
         Parameters
         ----------
         waveform : tensor
             Input audio waveform.
-
-        Returns
-        -------
-        waveform : tensor
-            Waveform of fixed length (trimmed or zero-padded).
+        random_crop : bool
+            Whether to randomly crop/pad (augmentation).
         """
         num_samples = waveform.shape[-1]
 
-        if self.TARGET_NUM_SAMPLE < num_samples:
-            print(f"Audio {num_samples} longer than {self.TARGET_NUM_SAMPLE}. Starting trimming.")
-            return waveform[..., :self.TARGET_NUM_SAMPLE]
-        elif self.TARGET_NUM_SAMPLE > num_samples:
-            print(f"Audio {num_samples} shorter than {self.TARGET_NUM_SAMPLE}. Starting padding.")
+        if num_samples > self.TARGET_NUM_SAMPLE:
+            # Trim with optional random crop
+            if random_crop:
+                max_start = num_samples - self.TARGET_NUM_SAMPLE
+                start = random.randint(0, max_start)
+                return waveform[..., start:start + self.TARGET_NUM_SAMPLE]
+            else:
+                return waveform[..., :self.TARGET_NUM_SAMPLE]
+
+        elif num_samples < self.TARGET_NUM_SAMPLE:
             padding_amount = self.TARGET_NUM_SAMPLE - num_samples
-            return F.pad(
-                waveform, 
-                (0, padding_amount), 
-            )
+            if random_crop:
+                # Randomly distribute padding left vs right
+                left = random.randint(0, padding_amount)
+                right = padding_amount - left
+                return F.pad(waveform, (left, right))
+            else:
+                # Default: pad at the end
+                return F.pad(waveform, (0, padding_amount))
+
         else:
             return waveform
         
@@ -184,60 +194,25 @@ class AudioPreprocessor:
         torchaudio.save(str(output_path), waveform, self.TARGET_SAMPLING)
 
 
-    def download_preprocessed(self, filename, skip_time=0):
+    def __call__(self, file, skip_time=0, train=False):
         """
-        Full preprocessing pipeline that loads, normalizes, and saves spectrogram.
+        Process an audio file and return its normalized waveform.
 
         Parameters
         ----------
-        filename : str
-            Name of the audio file to process.
+        file : str/audio_media
+            Path of the audio to process or audio media from the API
         skip_time : float
             Number of seconds to skip from the start of the file.
-        """
-        waveform, sample_rate = self.load_saved_audio(filename)
-    
-        # Resample the audio to 16kHz
-        waveform = self.resample_audio(original_sr=sample_rate, waveform=waveform)
-
-        # Convert the audio into mono
-        if waveform.shape[0] > 1:
-            print("Current audio is stereo. Converting to mono.")
-            waveform = waveform.mean(dim=0, keepdim=True)
-
-        # If there is a skip value provided, trim it
-        if skip_time is not None and skip_time > 0:
-            print(f"Skipping first {skip_time:.2f} seconds.")
-            start_sample = int(skip_time * self.TARGET_SAMPLING)
-            waveform = waveform[:, start_sample:]
-
-        # Trim if more than 120 seconds, pad if less than
-        waveform = self.pad_trim(waveform=waveform)
-
-        # Normalize waveform (aligned with SONICS)
-        waveform = self.normalize_waveform(waveform, method=self.WAVEFORM_NORM)
-
-        # Save the spectrogram
-        self.save_waveform(waveform, filename)
-
-
-    def __call__(self, filename, skip_time=0):
-        """
-        Process an audio file and return its normalized log-Mel spectrogram.
-
-        Parameters
-        ----------
-        filename : str
-            Name of the audio file to process.
-        skip_time : float
-            Number of seconds to skip from the start of the file.
+        train : boolean
+            False for inference/prediction, True for training.
 
         Returns
         -------
         tensor
-            Normalized log-Mel spectrogram.
+            Normalized tensor of a waveform
         """
-        waveform, sample_rate = self.load_audio(filename)
+        waveform, sample_rate = self.load_audio(file)
     
         # Resample the audio to 16kHz
         waveform = self.resample_audio(original_sr=sample_rate, waveform=waveform)
@@ -254,9 +229,12 @@ class AudioPreprocessor:
             waveform = waveform[:, start_sample:]
 
         # Trim if more than 120 seconds, pad if less than
-        waveform = self.pad_trim(waveform=waveform)
+        waveform = self.pad_trim(waveform=waveform, random_crop=train)
 
         # Normalize waveform (aligned with SONICS)
         waveform = self.normalize_waveform(waveform, method=self.WAVEFORM_NORM)
+
+        # Add some gaussian noise to the waveform
+        waveform += torch.randn_like(waveform) * 1e-4
 
         return waveform

--- a/src/preprocessing/audio_preprocessor.py
+++ b/src/preprocessing/audio_preprocessor.py
@@ -234,7 +234,8 @@ class AudioPreprocessor:
         # Normalize waveform (aligned with SONICS)
         waveform = self.normalize_waveform(waveform, method=self.WAVEFORM_NORM)
 
-        # Add some gaussian noise to the waveform
-        waveform += torch.randn_like(waveform) * 1e-4
+        # Add some gaussian noise to the waveform during training
+        if train:
+            waveform += torch.randn_like(waveform) * 1e-4
 
         return waveform

--- a/src/preprocessing/audio_preprocessor.py
+++ b/src/preprocessing/audio_preprocessor.py
@@ -66,7 +66,7 @@ class AudioPreprocessor:
             The original sampling rate of the audio.
         """
         try:
-            ext = 'wav'
+            ext = 'mp3'
             if '.' in filename:
                 filename, ext = filename.split('.')
             file_path = self.INPUT_PATH / f"{filename}.{ext}"

--- a/src/preprocessing/preprocessor.py
+++ b/src/preprocessing/preprocessor.py
@@ -40,7 +40,7 @@ def bulk_preprocessing(batch, batch_count: int):
 
     for row in batch.itertuples():
         print(f"Batch {batch_count}     -    {count}/{batch_length}")
-        processed_song = audio_preprocessor(filename=row.directory)
+        processed_song = audio_preprocessor(file=row.directory, skip_time=row.skip_time, train=True)
         audio_list.append(processed_song)
 
         processed_lyric = lyric_preprocessor(lyrics=row.lyrics)
@@ -75,8 +75,8 @@ def single_preprocessing(audio, lyric):
     audio_preprocessor = AudioPreprocessor(script="predict")
     lyric_preprocessor = LyricsPreprocessor()
 
+    # Preprocess both song and lyrics
     processed_song = audio_preprocessor(filename=audio)
-
     processed_lyric = lyric_preprocessor(lyrics=lyric)
 
     return processed_song, processed_lyric
@@ -101,7 +101,7 @@ def dataset_read():
     dataset = pd.read_csv(dataset_path)
     label = dataset['target'].tolist()
 
-    # split into twenty sections
-    data_splits = np.array_split(dataset, 20)
+    # split into 25 sections (2,000 per batch from 50k sample)
+    data_splits = np.array_split(dataset, 25)
 
     return data_splits, label

--- a/src/preprocessing/preprocessor.py
+++ b/src/preprocessing/preprocessor.py
@@ -65,8 +65,8 @@ def single_preprocessing(audio, lyric: str):
 
     Returns
     -------
-    processed_song : audio_object
-        Audio object file
+    processed_song : tensor
+        Tensor version of the audio
     
     processed_lyric : string
         Lyric string

--- a/src/preprocessing/preprocessor.py
+++ b/src/preprocessing/preprocessor.py
@@ -40,7 +40,7 @@ def bulk_preprocessing(batch, batch_count: int):
 
     for row in batch.itertuples():
         print(f"Batch {batch_count}     -    {count}/{batch_length}")
-        processed_song = audio_preprocessor(filename=row.id)
+        processed_song = audio_preprocessor(filename=row.directory)
         audio_list.append(processed_song)
 
         processed_lyric = lyric_preprocessor(lyrics=row.lyrics)


### PR DESCRIPTION
## Summary
Added MixUp augmentation to the MLP training pipeline for improved generalization on embedded features. Updated the training loop to handle MixUp when mixup_alpha > 0 in the configuration. Added PCA implementation for LLM2Vec for more general vectors. Polished audio preprocessing to add augmentation and variability.

### Changes Made
- [x] Implemented `mixup` and `mixup_loss` methods in MLPModel.
- [x] Updated `MLPClassifier.train()` to use MixUp augmentation when enabled in config.
- [x] Added config parameter `mixup_alpha` to control MixUp strength.
- [x] Refactored training loop to support MixUp without breaking existing functionality.
- [x] Added flexibility on reading audio via Librosa.
- [x] Added randomization on cropping/padding audio.
- [x] Added gaussian noise on waveform before returning.
- [x] Added preprocessing documentation inside `docs/`.
- [x] Adjusted and added comments. 

### Notes
- MixUp is applied only during training. Other methods such as prediction and validation should be unchanged.
- Future PRs can integrate MixUp with other data augmentation strategies for further performance improvements.
- One thing that I got to search about more is that saving preprocessed songs and then re-loading it could actually introduce artifacts. With that in mind, I opted to just upload the raw files, and let the Google Colab runs preprocess it and directly return it to the feature extractors. It might help to reduce tendencies of overfitting.