### PR TITLE
[FEAT] Model change and Quantization for CPU processing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "timm (>=1.0.19,<2.0.0)",
     "pyyaml (>=6.0.2,<7.0.0)",
     "tqdm (>=4.67.1,<5.0.0)",
-    "scikit-learn (>=1.5.2)"
+    "scikit-learn (>=1.5.2)",
+    "torchao" (==0.13.0),
 ]
 
 

--- a/src/llm2vectrain/model.py
+++ b/src/llm2vectrain/model.py
@@ -3,32 +3,46 @@ from transformers import AutoTokenizer, AutoModel, AutoConfig
 from peft import PeftModel
 from src.llm2vectrain.access_token import access_token
 import torch
+from torchao.quantization import quantize_, Int8WeightOnlyConfig
 
 
 def load_llm2vec_model():
-    tokenizer = AutoTokenizer.from_pretrained(
-        "McGill-NLP/LLM2Vec-Meta-Llama-31-8B-Instruct-mntp"
-    )
-    config = AutoConfig.from_pretrained(
-        "McGill-NLP/LLM2Vec-Meta-Llama-31-8B-Instruct-mntp", trust_remote_code=True
-    )
-    model = AutoModel.from_pretrained(
-        "McGill-NLP/LLM2Vec-Meta-Llama-31-8B-Instruct-mntp",
+    
+    model_id = "McGill-NLP/LLM2Vec-Sheared-LLaMA-mntp"
+    
+    tokenizer = AutoTokenizer.from_pretrained(model_id, padding = True, truncation = True, max_length = 512)
+    config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
+    
+    if torch.cuda.is_available():
+    # GPU path: use bf16 for speed
+        model = AutoModel.from_pretrained(
+        model_id,
         trust_remote_code=True,
         config=config,
         torch_dtype=torch.bfloat16,
-        device_map="cuda" if torch.cuda.is_available() else "cpu",
+        device_map="cuda",
         token=access_token,
     )
-
-    model = PeftModel.from_pretrained(
-        model,
-        "McGill-NLP/LLM2Vec-Meta-Llama-31-8B-Instruct-mntp",
+    else:
+    # CPU path: use float32 first, then quantize
+        model = AutoModel.from_pretrained(
+        model_id,
+        trust_remote_code=True,
+        config=config,
+        torch_dtype=torch.float32,   # quantization requires fp32
+        device_map="cpu",
+        token=access_token,
     )
-
-    model = PeftModel.from_pretrained(
-        model, "McGill-NLP/LLM2Vec-Meta-Llama-31-8B-Instruct-mntp-supervised"
-    )
+    
+    try:
+        from torchao.quantization import quantize_
+        print("[INFO] Applying torchao quantization for CPU...")
+        quant_config = Int8WeightOnlyConfig(group_size=None)
+        print("[INFO] Applying torchao quantization with Int8WeightOnlyConfig...")
+        quantize_(model, quant_config)
+    except ImportError:
+        print("[WARNING] torchao not installed. Run: pip install torchao")
+        print("[WARNING] Falling back to non-quantized CPU model.")
 
     l2v = LLM2Vec(model, tokenizer, pooling_mode="mean", max_length=512)
     return l2v


### PR DESCRIPTION
**SUMMARY**
Changed the model used for LLM2vec from Meta-Llama-3-8B (Bi + MNTP + Supervised) to Sheared-Llama-1.3B (Bi + MNTP). Added Quantization in order to enhance the processing of the model for efficient CPU-based inference.

**Changes Made**

- [x] Refactored the LLM2Vec model architecture to a smaller model.
- [x] Added quantization support using PyTorch utilities for optimized CPU processing.
- [x] Benchmarked quantized inference on CPU.
- [x] Added TorchAO as a dependency.