### PR TITLE
[FEAT] Added pytest and sample test scripts

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -469,7 +469,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main"]
-markers = "platform_system == \"Windows\""
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -1048,6 +1048,18 @@ pyav = ["av"]
 rawpy = ["numpy (>2)", "rawpy"]
 test = ["fsspec[github]", "pytest", "pytest-cov"]
 tifffile = ["tifffile"]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+]
 
 [[package]]
 name = "inquirerpy"
@@ -2408,6 +2420,22 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-
 type = ["mypy (>=1.14.1)"]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pooch"
 version = "1.8.2"
 description = "A friend to fetch your data files"
@@ -2645,6 +2673,21 @@ files = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
+    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.5"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
@@ -2658,6 +2701,28 @@ files = [
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
+    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+iniconfig = ">=1"
+packaging = ">=20"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -4053,4 +4118,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "949842390ade494b1d4a8ce10d00c5fc5d2ad78bfa223626ad826b6120df51f9"
+content-hash = "41ce31b351ff888e2bead404f3371bc533ee1645d1383bd7d74f3d3d64dd5985"

--- a/poetry.lock
+++ b/poetry.lock
@@ -976,6 +976,7 @@ files = [
 filelock = "*"
 fsspec = ">=2023.5.0"
 hf-xet = {version = ">=1.1.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
+InquirerPy = {version = "0.3.4", optional = true, markers = "extra == \"cli\""}
 packaging = ">=20.9"
 pyyaml = ">=5.1"
 requests = "*"
@@ -1047,6 +1048,25 @@ pyav = ["av"]
 rawpy = ["numpy (>2)", "rawpy"]
 test = ["fsspec[github]", "pytest", "pytest-cov"]
 tifffile = ["tifffile"]
+
+[[package]]
+name = "inquirerpy"
+version = "0.3.4"
+description = "Python port of Inquirer.js (A collection of common interactive command-line user interfaces)"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "InquirerPy-0.3.4-py3-none-any.whl", hash = "sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4"},
+    {file = "InquirerPy-0.3.4.tar.gz", hash = "sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e"},
+]
+
+[package.dependencies]
+pfzy = ">=0.3.1,<0.4.0"
+prompt-toolkit = ">=3.0.1,<4.0.0"
+
+[package.extras]
+docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.4.0,<0.5.0)"]
 
 [[package]]
 name = "jinja2"
@@ -2231,6 +2251,21 @@ quality = ["black", "hf-doc-builder", "ruff (>=0.9.2,<0.10.0)"]
 test = ["black", "black", "datasets", "diffusers", "hf-doc-builder", "hf-doc-builder", "parameterized", "protobuf", "pytest", "pytest-cov", "pytest-xdist", "ruff (>=0.9.2,<0.10.0)", "scipy", "sentencepiece"]
 
 [[package]]
+name = "pfzy"
+version = "0.3.4"
+description = "Python port of the fzy fuzzy string matching algorithm"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "pfzy-0.3.4-py3-none-any.whl", hash = "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96"},
+    {file = "pfzy-0.3.4.tar.gz", hash = "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=4.1.2,<5.0.0)", "furo (>=2021.8.17-beta.43,<2022.0.0)", "myst-parser (>=0.15.1,<0.16.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.4.0,<0.5.0)"]
+
+[[package]]
 name = "pillow"
 version = "11.3.0"
 description = "Python Imaging Library (Fork)"
@@ -2393,6 +2428,21 @@ requests = ">=2.19.0"
 progress = ["tqdm (>=4.41.0,<5.0.0)"]
 sftp = ["paramiko (>=2.7.0)"]
 xxhash = ["xxhash (>=1.4.3)"]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+description = "Library for building powerful interactive command lines in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
+    {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
+]
+
+[package.dependencies]
+wcwidth = "*"
 
 [[package]]
 name = "propcache"
@@ -3737,6 +3787,18 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "wcwidth"
+version = "0.2.14"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1"},
+    {file = "wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"},
+]
+
+[[package]]
 name = "xxhash"
 version = "3.5.0"
 description = "Python binding for xxHash"
@@ -3991,4 +4053,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "ad7981d4a703a81c262ebc6997dc27cb5d44faaacf217ee0ad3523bc73f49280"
+content-hash = "949842390ade494b1d4a8ce10d00c5fc5d2ad78bfa223626ad826b6120df51f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "torchao (>=0.13.0,<0.14.0)",
     "lime (>=0.2.0.1,<0.3.0.0)",
     "hf-xet (>=1.1.10,<2.0.0)",
-    "huggingface-hub (>=0.35.3,<0.36.0)"
+    "huggingface-hub[cli] (>=0.35.3,<0.36.0)"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "torchao (>=0.13.0,<0.14.0)",
     "lime (>=0.2.0.1,<0.3.0.0)",
     "hf-xet (>=1.1.10,<2.0.0)",
-    "huggingface-hub[cli] (>=0.35.3,<0.36.0)"
+    "huggingface-hub[cli] (>=0.35.3,<0.36.0)",
+    "pytest (>=8.4.2,<9.0.0)"
 ]
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,2 @@
+# We can create MLP + SpecTTTra test cases here OR have diff files for the two
+# Note: Testing is ENTIRELY optional. If you don't want to create your own test case, it's okay

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -1,0 +1,79 @@
+import pytest
+import numpy as np
+import torch
+from src.models.mlp import build_mlp, load_config, MLPClassifier
+
+
+def test_mlp_model_creation():
+    config = load_config("config/model_config.yml")
+    classifier = build_mlp(input_dim=640, config=config)
+
+    # Test: We assert that MLP classifier is created properly
+    # It should have the correct input dimension and be an instance of MLPClassifier
+    assert isinstance(classifier, MLPClassifier)
+    assert classifier.model is not None
+
+
+def test_mlp_prediction_single():
+    config = load_config("config/model_config.yml")
+    classifier = build_mlp(input_dim=640, config=config)
+
+    # Create dummy features that match expected input dimension
+    dummy_features = np.random.randn(640)
+
+    # Test: We assert that single prediction works and returns expected format
+    # Probability should be between 0 and 1, prediction should be 0 or 1, label should be string
+    try:
+        probability, prediction, label = classifier.predict_single(dummy_features)
+        assert 0 <= probability <= 1
+        assert prediction in [0, 1]
+        assert label in ["AI-Generated", "Human-Composed"]
+    except ValueError as e:
+        # Test: If model isn't trained, it should raise a specific error message
+        # This is expected behavior when model hasn't been trained yet
+        assert "Model must be trained" in str(e)
+
+
+def test_mlp_prediction_batch():
+    config = load_config("config/model_config.yml")
+    classifier = build_mlp(input_dim=640, config=config)
+
+    # Create batch of dummy features
+    batch_features = np.random.randn(5, 640)
+
+    try:
+        probabilities, predictions = classifier.predict(batch_features)
+
+        # Test: We assert that batch prediction returns correct shapes and value ranges
+        # Probabilities should be array of length 5, predictions should be 0s and 1s
+        assert probabilities.shape == (5,)
+        assert predictions.shape == (5,)
+        assert all(0 <= p <= 1 for p in probabilities)
+        assert all(pred in [0, 1] for pred in predictions)
+    except ValueError as e:
+        # Test: Same as single prediction, untrained model should raise error
+        assert "Model must be trained" in str(e)
+
+
+def test_mlp_model_summary():
+    config = load_config("config/model_config.yml")
+    classifier = build_mlp(input_dim=640, config=config)
+
+    # Test: We assert that model summary doesn't crash and model has parameters
+    # This tests that the model architecture is properly constructed
+    try:
+        classifier.get_model_summary()
+        total_params = sum(p.numel() for p in classifier.model.parameters())
+        assert total_params > 0
+    except Exception as e:
+        pytest.fail(f"Model summary failed: {e}")
+
+
+def test_config_loading():
+    config = load_config("config/model_config.yml")
+
+    # Test: We assert that config loads properly and contains expected keys
+    assert "hidden_layers" in config
+    assert "dropout" in config
+    assert isinstance(config["hidden_layers"], list)
+    assert len(config["hidden_layers"]) > 0

--- a/tests/test_musiclime.py
+++ b/tests/test_musiclime.py
@@ -1,0 +1,178 @@
+import pytest
+import numpy as np
+import torch
+from src.musiclime.explainer import MusicLIMEExplainer, MusicLIMEExplanation
+from src.musiclime.factorization import OpenUnmixFactorization
+from src.musiclime.text_utils import LineIndexedString
+from src.musiclime.wrapper import MusicLIMEPredictor
+
+
+def test_line_indexed_string():
+    lyrics = "Line 1\nLine 2\n[Chorus]\nLine 3\n(Verse)\nLine 4"
+    indexed = LineIndexedString(lyrics)
+
+    # Test: We assert that line segmentation works correctly
+    # Should skip metadata like [Chorus] and (Verse), keep only actual lyrics
+    assert indexed.num_words() == 4  # Should have 4 actual lines
+    assert "Line 1" in indexed.as_list
+    assert "Line 4" in indexed.as_list
+    assert "[Chorus]" not in indexed.as_list
+    assert "(Verse)" not in indexed.as_list
+
+
+def test_line_indexed_string_inverse_removing():
+    lyrics = "Line 1\nLine 2\nLine 3\nLine 4"
+    indexed = LineIndexedString(lyrics)
+
+    # Remove lines at indices 1 and 3 (Line 2 and Line 4)
+    result = indexed.inverse_removing([1, 3])
+
+    # Test: We assert that inverse removing works correctly
+    # Should return only Line 1 and Line 3, joined by newlines
+    expected = "Line 1\nLine 3"
+    assert result == expected
+
+
+def test_audio_factorization_creation():
+    # Create dummy audio (5 seconds at 44.1kHz)
+    dummy_audio = np.random.randn(5 * 44100)
+
+    try:
+        factorization = OpenUnmixFactorization(
+            dummy_audio, temporal_segmentation_params=5
+        )
+
+        # Test: We assert that audio factorization creates expected components
+        # Should have 4 sources × 5 temporal segments = 20 total components
+        assert factorization.get_number_components() == 20
+        component_names = factorization.get_ordered_component_names()
+        assert len(component_names) == 20
+
+        # Test: Component names should follow expected pattern
+        # Should have vocals_T0, drums_T0, bass_T0, other_T0, vocals_T1, etc.
+        assert any("vocals_T" in name for name in component_names)
+        assert any("drums_T" in name for name in component_names)
+        assert any("bass_T" in name for name in component_names)
+        assert any("other_T" in name for name in component_names)
+
+    except Exception as e:
+        pytest.skip(f"OpenUnmix model not available: {e}")
+
+
+def test_audio_factorization_composition():
+    dummy_audio = np.random.randn(2 * 44100)  # 2 seconds
+
+    try:
+        factorization = OpenUnmixFactorization(
+            dummy_audio, temporal_segmentation_params=3
+        )
+
+        # Test composition with subset of components
+        selected_components = [0, 2, 4]  # Select some components
+        composed_audio = factorization.compose_model_input(selected_components)
+
+        # Test: We assert that composed audio has same length as original
+        # Composed audio should be same length, might be different amplitude
+        assert len(composed_audio) == len(dummy_audio)
+        assert isinstance(composed_audio, np.ndarray)
+
+    except Exception as e:
+        pytest.skip(f"OpenUnmix model not available: {e}")
+
+
+def test_musiclime_explainer_creation():
+    explainer = MusicLIMEExplainer(kernel_width=25, random_state=42)
+
+    # Test: We assert that MusicLIME explainer is created properly
+    # Should have required attributes for LIME explanation
+    assert explainer.random_state is not None
+    assert explainer.base is not None
+    assert hasattr(explainer, "explain_instance")
+
+
+def test_musiclime_explanation_object():
+    # Create mock objects for testing
+    dummy_audio_fact = type(
+        "MockFactorization",
+        (),
+        {
+            "get_number_components": lambda: 8,
+            "get_ordered_component_names": lambda: [f"comp_{i}" for i in range(8)],
+        },
+    )()
+
+    dummy_text_fact = type(
+        "MockTextFact", (), {"num_words": lambda: 4, "word": lambda i: f"line_{i}"}
+    )()
+
+    dummy_data = np.random.randint(0, 2, (10, 12))  # 10 samples, 12 features
+    dummy_predictions = np.random.rand(10, 2)  # 10 samples, 2 classes
+
+    explanation = MusicLIMEExplanation(
+        dummy_audio_fact, dummy_text_fact, dummy_data, dummy_predictions
+    )
+
+    # Test: We assert that explanation object is created with correct attributes
+    # Should have all required dictionaries for storing explanation results
+    assert hasattr(explanation, "intercept")
+    assert hasattr(explanation, "local_exp")
+    assert hasattr(explanation, "score")
+    assert hasattr(explanation, "local_pred")
+    assert isinstance(explanation.intercept, dict)
+    assert isinstance(explanation.local_exp, dict)
+
+
+def test_musiclime_predictor_creation():
+    try:
+        predictor = MusicLIMEPredictor()
+
+        # Test: We assert that MusicLIME predictor is created successfully
+        # Should have required attributes for prediction
+        assert hasattr(predictor, "__call__")
+        assert predictor.llm2vec_model is not None
+        assert predictor.config is not None
+
+    except Exception as e:
+        pytest.skip(f"MusicLIME predictor dependencies not available: {e}")
+
+
+def test_perturbation_data_generation():
+    explainer = MusicLIMEExplainer(random_state=42)
+
+    # Create simple mock objects
+    audio_fact = type(
+        "MockAudioFact",
+        (),
+        {
+            "get_number_components": lambda self: 4,
+            "compose_model_input": lambda self, indices: np.random.randn(1000),
+        },
+    )()
+
+    text_fact = type(
+        "MockTextFact",
+        (),
+        {
+            "num_words": lambda self: 3,
+            "inverse_removing": lambda self, indices: "remaining text",
+        },
+    )()
+
+    # Mock predict function
+    def mock_predict_fn(texts, audios):
+        return np.random.rand(len(texts), 2)
+
+    try:
+        data, predictions, distances = explainer._generate_neighborhood(
+            audio_fact, text_fact, mock_predict_fn, num_samples=5
+        )
+
+        # Test: We assert that perturbation generation works correctly
+        # Should return data, predictions, and distances with correct shapes
+        assert data.shape == (5, 7)  # 5 samples, 7 features (4 audio + 3 text)
+        assert predictions.shape == (5, 2)  # 5 samples, 2 classes
+        assert len(distances) == 5  # 5 distance values
+        assert data[0].sum() == 7  # First sample should be all 1s (original)
+
+    except Exception as e:
+        pytest.fail(f"Perturbation generation failed: {e}")


### PR DESCRIPTION
This branch is not related to the model itself. I just added pytest just in case you want to create unit/integration tests in code. I also added sample test scripts for MusicLIME and MLP. Check our gc for the detailed steps on how to create and/or run your own test script/batch of test scripts. Thanks